### PR TITLE
Replace iptrackeronline.com links with ipinfo.io

### DIFF
--- a/ProtectingYourData/session01-ip.html
+++ b/ProtectingYourData/session01-ip.html
@@ -133,7 +133,7 @@ of digits that looks something like 192.206.151.131. </p>
 
                             <h3>Look up your IP address</h3>
 
-							<p>Using an online resource to trace IP addresses (i.e., <a href="http://who.is">http://who.is</a> or <a href="http://www.iptrackeronline.com/">http://www.iptrackeronline.com/</a> or another of your choosing), <strong>look up your IP address.</strong></p>
+							<p>Using an online resource to trace IP addresses (i.e., <a href="http://who.is">http://who.is</a> or <a href="http://ipinfo.io/">http://ipinfo.io</a> or another of your choosing), <strong>look up your IP address.</strong></p>
 								<p><strong>Discuss</strong> whether the IP address reveals any information about you and what an IP address is.</p>   
                             </div>
                     </li>

--- a/ProtectingYourData/session01-ip.html
+++ b/ProtectingYourData/session01-ip.html
@@ -168,7 +168,7 @@ of digits that looks something like 192.206.151.131. </p>
                            
 							<h3>IP Addresses of Your Favourite Sites</h3>
 								<p>Alone or in a group, generate a list of your 5 favourite websites.</p>
-									<p><strong>Look up the IP address of your 5 favourite websites</strong> using an an online resource to trace IP addresses (i.e., <a href="http://www.iptrackeronline.com/">http://www.iptrackeronline.com/</a>). Identify and collect information about 5 of your favourite websites:</p>
+									<p><strong>Look up the IP address of your 5 favourite websites</strong> using an an online resource to trace IP addresses (i.e., <a href="http://ipinfo.io">http://ipinfo.io</a>). Identify and collect information about 5 of your favourite websites:</p>
 									<div class="well example">
 										<p>Take notes on the following:</p>
 											<ul> 


### PR DESCRIPTION
The guide currently links to iptrackeronline.com, suggesting people lookup IP address information there. The site is full of ads, is slow the load and doesn't display the IP information very clearly. I've replaced it instead with links to ipinfo.io, which is quick, clear, and provides more information. Compare http://www.iptrackeronline.com/index.php?ip_address=8.8.8.8 to http://ipinfo.io/8.8.8.8. Screenshots also attached:

<img width="1364" alt="screen shot 2015-08-29 at 10 41 50 am" src="https://cloud.githubusercontent.com/assets/26079/9563504/d0795e06-4e3a-11e5-8b33-c893bc42d552.png">

<img width="775" alt="screen shot 2015-08-29 at 10 42 10 am" src="https://cloud.githubusercontent.com/assets/26079/9563505/d146e6fa-4e3a-11e5-8b74-2c82592c2dd7.png">
